### PR TITLE
Fix iterating over sub-folders

### DIFF
--- a/findmaildirs.c
+++ b/findmaildirs.c
@@ -61,6 +61,11 @@ void checkdir(const char* path, const char* prefix) {
 
 		if (strcmp(de->d_name, "cur") == 0) {
 			printf("+%s ", prefix);
+		}
+
+		if (strcmp(de->d_name, "cur") == 0
+			|| strcmp(de->d_name, "new") == 0
+			|| strcmp(de->d_name, "tmp") == 0) {
 		} else {
 			if (prefix == NULL)
 				snprintf(fullprefix, sizeof(fullprefix), "%s", de->d_name);

--- a/findmaildirs.c
+++ b/findmaildirs.c
@@ -59,14 +59,12 @@ void checkdir(const char* path, const char* prefix) {
 		if (!S_ISDIR(st.st_mode))
 			continue;
 
-		if (strcmp(de->d_name, "cur") == 0) {
+		if (strcmp(de->d_name, "cur") == 0)
 			printf("+%s ", prefix);
-		}
 
-		if (strcmp(de->d_name, "cur") == 0
-			|| strcmp(de->d_name, "new") == 0
-			|| strcmp(de->d_name, "tmp") == 0) {
-		} else {
+		if (strcmp(de->d_name, "cur") != 0
+			&& strcmp(de->d_name, "new") != 0
+			&& strcmp(de->d_name, "tmp") != 0) {
 			if (prefix == NULL)
 				snprintf(fullprefix, sizeof(fullprefix), "%s", de->d_name);
 			else

--- a/findmaildirs.c
+++ b/findmaildirs.c
@@ -59,11 +59,8 @@ void checkdir(const char* path, const char* prefix) {
 		if (!S_ISDIR(st.st_mode))
 			continue;
 
-		if (strcmp(de->d_name, "cur") == 0 || strcmp(de->d_name, "new") == 0 || strcmp(de->d_name, "tmp") == 0) {
+		if (strcmp(de->d_name, "cur") == 0) {
 			printf("+%s ", prefix);
-			if (closedir(d) != 0)
-				errx(1, "closedir");
-			return;
 		} else {
 			if (prefix == NULL)
 				snprintf(fullprefix, sizeof(fullprefix), "%s", de->d_name);


### PR DESCRIPTION
This is necessary for situation such as:

```
~/.mail
   inbox
      cur
      new
      tmp
      maillists
        cur
        new
        tmp
        mailman
          cur
          new
          tmp
```

With the former approach the iteration was stopped as it assumed there
was no sub-folder within the maildir folder, but that can actually
happen and with this change, findmaildirs supports this.
